### PR TITLE
Change GitHub link to korean repository

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -39,7 +39,7 @@
 				<span class="large"><Icon name="discord" /></span>
 			</a>
 
-			<a href="https://github.com/sveltejs/learn.svelte.dev" title="GitHub Repo">
+			<a href="https://github.com/Svelte-Korea/learn.svelte.kr" title="GitHub Repo">
 				<span class="small">GitHub</span>
 				<span class="large"><Icon name="github" /></span>
 			</a>


### PR DESCRIPTION
Close #15 

GitHub 아이콘을 눌렀을 때 열리는 저장소 주소를 변경했습니다.