### PR TITLE
01-svelte/04-logic/06-await-blocks 번역

### DIFF
--- a/content/tutorial/01-svelte/04-logic/06-await-blocks/README.md
+++ b/content/tutorial/01-svelte/04-logic/06-await-blocks/README.md
@@ -1,8 +1,8 @@
 ---
-title: Await blocks
+title: Await 블록
 ---
 
-Most web applications have to deal with asynchronous data at some point. Svelte makes it easy to _await_ the value of [promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) directly in your markup:
+대부분의 웹 애플리케이션은 어느 시점에서 비동기 데이터를 처리해야 합니다. 스벨트에서는 마크업 내에서 직접 [promises](https://developer.mozilla.org/ko-KR/docs/Web/JavaScript/Guide/Using_promises)의 값을 _기다리는(await)_ 것을 쉽게 처리할 수 있습니다.
 
 ```svelte
 /// file: App.svelte
@@ -15,9 +15,9 @@ Most web applications have to deal with asynchronous data at some point. Svelte 
 {/await}+++
 ```
 
-> Only the most recent `promise` is considered, meaning you don't need to worry about race conditions.
+> 가장 최근 `프로미스(promise)` 만 고려되므로, 레이스 컨디션을 걱정할 필요가 없습니다.
 
-If you know that your promise can't reject, you can omit the `catch` block. You can also omit the first block if you don't want to show anything until the promise resolves:
+프로미스가 거부(reject)되지 않는 상황이면, `catch` 블록은 없어도 됩니다. 프로미스가 수행(resolve) 되기 전까지 아무것도 보여주기 싫다면 첫 블록을 제거해 버리면 됩니다.
 
 ```svelte
 /// no-file

--- a/content/tutorial/01-svelte/04-logic/meta.json
+++ b/content/tutorial/01-svelte/04-logic/meta.json
@@ -1,5 +1,5 @@
 {
-	"title": "Logic",
+	"title": "로직",
 	"scope": {
 		"prefix": "/src/lib/",
 		"name": "src"


### PR DESCRIPTION
Close #98 

01-svelte/04-logic/06-await-blocks README.md, 01-svelte/04-logic meta.json 번역했습니다.

- [번역 풀 리퀘스트Translation PR Template](?expand=1&template=translation_pr_template.md)
